### PR TITLE
Fix build errors

### DIFF
--- a/hal/Android.mk
+++ b/hal/Android.mk
@@ -227,7 +227,8 @@ LOCAL_SHARED_LIBRARIES := \
 	libtinycompress \
 	libaudioroute \
 	libdl \
-	libexpat
+	libexpat \
+	libprocessgroup
 
 LOCAL_C_INCLUDES += \
 	external/tinyalsa/include \


### PR DESCRIPTION
- hal/Android.mk: set_sched_policy() was moved from libcutils to libprocessgroup

Change-Id: I97b04edc55e457c0572c67bf16801cc3b9366d06